### PR TITLE
Updated to work with the new npmjs.com layout

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -1,5 +1,5 @@
-const packageName = document.querySelector('.package-name a').textContent;
-const lastListItem = document.querySelector('.sidebar .box li:last-child');
+const packageHeader = document.querySelector('main h1');
+const packageName = packageHeader.textContent;
 const cdnUri = `https://unpkg.com/${packageName}/`;
 
-lastListItem.insertAdjacentHTML('afterend', `<li><a href="${cdnUri}">View Code</a></li>`);
+packageHeader.insertAdjacentHTML('afterend', `<p><a href="${cdnUri}">View on unpkg</a></p>`);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "unpkg Link",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "description": "Adds a link to unpkg.com for packages on npmjs.org",
     "homepage_url": "https://github.com/DrewML/unpkg-link",
     "manifest_version": 2,


### PR DESCRIPTION
Updated to work with the new npmjs.com layout.
Moved the link just below the package name header, because the selectors in the sidebar are looks auto-generated and a their names a bit too fragile to use with `document.querySelector`.
![www npmjs com_package_react](https://user-images.githubusercontent.com/59037/39049509-0938bc40-44a2-11e8-9746-2c05bd8ce60a.png)
