### PR TITLE
Handle content changes with MutationObserver or Mutation events

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -1,5 +1,38 @@
-const packageHeader = document.querySelector('main h1');
-const packageName = packageHeader.textContent;
-const cdnUri = `https://unpkg.com/${packageName}/`;
+const addPackageHeader = () => {
+    // Don't inject if already injected
+    if(document.querySelector("[data-npmcdnlink]")){
+        return;
+    }
 
-packageHeader.insertAdjacentHTML('afterend', `<p><a href="${cdnUri}">View on unpkg</a></p>`);
+    // The best location for the unpkg link ?
+    const packageHeader = document.querySelector('main h1');
+    if(packageHeader){
+        const packageName = packageHeader.textContent;
+        const cdnUri = `https://unpkg.com/${packageName}/`;
+
+        // insert adjacent to h1
+        packageHeader.insertAdjacentHTML('afterend', `<p data-npmcdnlink><a href="${cdnUri}">View on unpkg</a></p>`);
+    }
+}
+
+// MutationObserver is prefixed in some browsers
+let MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
+if(MutationObserver) {
+
+    // Use MutationObserver to detect tab/page navigation
+    const observer = new MutationObserver(addPackageHeader);
+    observer.observe(
+        document.querySelector("[data-reactroot] #top"),
+        {
+            childList: true,
+            subtree: true
+        }
+    );
+} else {
+
+    // Use Mutation events to detect tab/page navigation
+    document.querySelector("[data-reactroot] #top").addEventListener("DOMSubtreeModified", addPackageHeader);
+}
+
+// initial
+addPackageHeader();

--- a/extension/index.js
+++ b/extension/index.js
@@ -1,5 +1,10 @@
 const addPackageHeader = () => {
-    // Don't inject if already injected
+    // Abort if not on a package url
+    if(location.pathname.indexOf("/package/") !== 0){
+        return;
+    }
+    
+    // Abort if already injected
     if(document.querySelector("[data-npmcdnlink]")){
         return;
     }
@@ -10,7 +15,7 @@ const addPackageHeader = () => {
         const packageName = packageHeader.textContent;
         const cdnUri = `https://unpkg.com/${packageName}/`;
 
-        // insert adjacent to h1
+        // Insert adjacent to h1
         packageHeader.insertAdjacentHTML('afterend', `<p data-npmcdnlink><a href="${cdnUri}">View on unpkg</a></p>`);
     }
 }
@@ -22,7 +27,7 @@ if(MutationObserver) {
     // Use MutationObserver to detect tab/page navigation
     const observer = new MutationObserver(addPackageHeader);
     observer.observe(
-        document.querySelector("[data-reactroot] #top"),
+        document.querySelector("[data-reactroot]"),
         {
             childList: true,
             subtree: true
@@ -31,8 +36,8 @@ if(MutationObserver) {
 } else {
 
     // Use Mutation events to detect tab/page navigation
-    document.querySelector("[data-reactroot] #top").addEventListener("DOMSubtreeModified", addPackageHeader);
+    document.querySelector("[data-reactroot]").addEventListener("DOMSubtreeModified", addPackageHeader);
 }
 
-// initial
+// Initial
 addPackageHeader();

--- a/extension/index.js
+++ b/extension/index.js
@@ -10,13 +10,13 @@ const addPackageHeader = () => {
     }
 
     // The best location for the unpkg link ?
-    const packageHeader = document.querySelector('main h1');
+    const packageHeader = document.querySelector('main h2');
     if(packageHeader){
-        const packageName = packageHeader.textContent;
+        const packageName = packageHeader.querySelector("span").textContent;
         const cdnUri = `https://unpkg.com/${packageName}/`;
 
         // Insert adjacent to h1
-        packageHeader.insertAdjacentHTML('afterend', `<p data-npmcdnlink><a href="${cdnUri}">View on unpkg</a></p>`);
+        packageHeader.insertAdjacentHTML('afterend', `<p data-npmcdnlink style="padding-left: 1em;"><a href="${cdnUri}">View on unpkg</a></p>`);
     }
 }
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,17 +1,17 @@
 {
     "name": "unpkg Link",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Adds a link to unpkg.com for packages on npmjs.org",
     "homepage_url": "https://github.com/DrewML/unpkg-link",
     "manifest_version": 2,
     "minimum_chrome_version": "49",
     "permissions": [
-        "https://www.npmjs.com/package/*"
+        "https://www.npmjs.com/*"
     ],
     "content_scripts": [
         {
             "run_at": "document_idle",
-            "matches": ["https://www.npmjs.com/package/*"],
+            "matches": ["https://www.npmjs.com/*"],
             "js": ["index.js"]
         }
     ]


### PR DESCRIPTION
Updated to use MutationObserver (where available) or Mutation events (fallback, but deprecated) to handle re-injecting the unpkg link on navigation (with tabs on package page, between packages, and between other pages on npmjs.org).